### PR TITLE
Add button to create snapshot doc from template (#9)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,6 +87,7 @@ gem 'pg_query', '>= 0.9.0'
 gem 'scenic'
 gem 'grpc', '1.9.1' # tmp fix for grpc#13908
 gem 'mixpanel-ruby'
+gem 'nokogiri'
 
 group :test do
   gem 'minitest', '~> 5.11.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -651,6 +651,7 @@ DEPENDENCIES
   minitest (~> 5.11.2)
   mixpanel-ruby
   neography
+  nokogiri
   omniauth
   omniauth-google-oauth2
   ox (>= 2.1.2)

--- a/app/controllers/internal/companies_controller.rb
+++ b/app/controllers/internal/companies_controller.rb
@@ -37,6 +37,11 @@ class Internal::CompaniesController < Internal::ApplicationController
     render 'index'
   end
 
+  def create_snapshot
+    company = Company.find(params[:id])
+    redirect_to company.create_snapshot_doc!
+  end
+
   private
 
   def flash_if_no_filter

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -74,6 +74,10 @@ class Team < ApplicationRecord
     config['excludes'] || []
   end
 
+  def snapshot_template
+    config['snapshot_template']
+  end
+
   def prevote_discussions_folder_id
     config['prevote_discussions']
   end

--- a/app/views/internal/companies/show.html.erb
+++ b/app/views/internal/companies/show.html.erb
@@ -9,6 +9,12 @@
       <a class="btn btn-default" href="<%= @company.pitch.snapshot %>" role="button" target="_blank">
         <h4>View Snapshot</h4>
       </a>
+    <% else %>
+      <%= form_tag({controller: 'internal/companies', id: @company.id, action: 'create_snapshot'}, target: '_blank') do %>
+        <button class="btn btn-primary" type="submit">
+          <h4>Create Snapshot</h4>
+        </button>
+      <% end %>
     <% end %>
     <% if @vote.present? %>
       <% if @vote.final? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -185,6 +185,9 @@ Rails.application.routes.draw do
         get 'voting', to: 'companies#voting'
         resources :companies, only: [:index, :show] do
           resources :votes, only: [:show, :create, :new]
+          member do
+            post 'create_snapshot'
+          end
         end
       end
 

--- a/config/teams.yml
+++ b/config/teams.yml
@@ -53,6 +53,8 @@ nyc:
     - '0B40v9HWp1QGqMnlCLXVxYUswa00'
     - '0BxwhX9OPjSH_M0ozSGZKRzVMV1k'
     - '0BxwhX9OPjSH_blpueVNpVlIzZHc'
+    - '1ARR7WwvAn7m4jp5WyVb-hpBaZIFamz3X' # 2018
+  snapshot_template: '1PVZIpOTQOiS-m8nEKeE-Fgl6xB6uXvwWyygWBW0Lup4'
   prevote_discussions: '0B5YV7AKNT7yocjBRa3NrdmtQWk0'
   coffee_chats: '0B5YV7AKNT7yoZW9MUC1nTktyeEU'
   lists:


### PR DESCRIPTION
Adds a button to the company page that creates and fills in a snapshot document in the latest snapshots folder. It pulls the template from a Google Doc and does string replacement to fill in some fields.

![image](https://user-images.githubusercontent.com/376616/37323766-2fb10f44-265c-11e8-9ea5-a84817711415.png)

![image](https://user-images.githubusercontent.com/376616/37323807-5c30ca1e-265c-11e8-97f4-97ac52c3d18c.png)

![image](https://user-images.githubusercontent.com/376616/37323818-639872ca-265c-11e8-8b40-1901b998fa3e.png)



## TODO
- What other fields might be needed?
- Add other cities to config besides NYC
- Maybe add a snapshot field to the company too
